### PR TITLE
update ctools.data

### DIFF
--- a/ctools/data/collate_fn.py
+++ b/ctools/data/collate_fn.py
@@ -1,9 +1,15 @@
 from collections.abc import Sequence, Mapping
 from typing import List, Dict, Union, Any
-
-import torch
 import re
-from torch._six import container_abcs, string_classes, int_classes
+import typing
+
+import numpy as np
+import torch
+import torch.utils.data
+
+import collections.abc as container_abcs
+from torch._six import string_classes
+int_classes = (bool, int)
 
 np_str_obj_array_pattern = re.compile(r'[SaUO]')
 
@@ -13,7 +19,7 @@ default_collate_err_msg_format = (
 )
 
 
-def default_collate(batch: Sequence) -> Union[torch.Tensor, Mapping, Sequence]:
+def default_collate(batch: typing.Sequence[Union[torch.Tensor, np.ndarray, float, int, bool]]) -> Union[torch.Tensor, Mapping, Sequence]:
     """
     Overview:
         Put each data field into a tensor with outer dimension batch size.
@@ -117,7 +123,7 @@ def timestep_collate(batch: List[Dict[str, Any]]) -> Dict[str, Union[torch.Tenso
     return batch
 
 
-def diff_shape_collate(batch: Sequence) -> Union[torch.Tensor, Mapping, Sequence]:
+def diff_shape_collate(batch: typing.Sequence[Union[torch.Tensor, np.ndarray, float, int, bool]]) -> Union[torch.Tensor, Mapping, Sequence]:
     """
     Overview:
         Similar to ``default_collate``, put each data field into a tensor with outer dimension batch size.

--- a/ctools/data/star_buffer.py
+++ b/ctools/data/star_buffer.py
@@ -1,12 +1,13 @@
-from collections import deque
 import time
 import os
-from ctools.utils import remove_file
-import queue
 import threading
+from collections import deque
+from typing import Optional
 
-class StarBuffer(object):
-    def __init__(self, cfg, name):
+
+class StarBuffer:
+    def __init__(self, cfg: 'EasyDict', name: str):
+        # TODO(Local State) is `StarBuffer` possible? And this class might be implemented incompletely, like ReplayBuffer.
         self.name = name
         self.meta_maxlen = cfg.meta_maxlen
         self.min_sample_ratio = cfg.min_sample_ratio
@@ -27,7 +28,7 @@ class StarBuffer(object):
         if self.total_data_count < self.min_sample_ratio:
             self.total_data_count += 1
 
-    def sample(self, batch_size):
+    def sample(self, batch_size: int) -> Optional[list]:
         if self.total_data_count < self.min_sample_ratio:
             print(f'not enough data, required {self.min_sample_ratio} to begin, now has {self.total_data_count}!')
             return None

--- a/ctools/data/structure/cache.py
+++ b/ctools/data/structure/cache.py
@@ -15,7 +15,7 @@ class Cache:
         remain_data_count
     """
 
-    def __init__(self, maxlen, timeout, monitor_interval=1.0, _debug=False):
+    def __init__(self, maxlen: int, timeout: float, monitor_interval: float = 1.0, _debug: bool = False):
         r"""
         Overview:
             initialize the cache object
@@ -83,7 +83,7 @@ class Cache:
                     if not is_timeout:
                         break
 
-    def _warn_if_timeout(self):
+    def _warn_if_timeout(self) -> bool:
         r"""
         Overview:
             return whether is timeout
@@ -122,7 +122,7 @@ class Cache:
             print('[CACHE] ' + s)
 
     @property
-    def remain_data_count(self):
+    def remain_data_count(self) -> int:
         r"""
         Overview:
             return the remain data count in the receive queue

--- a/ctools/data/structure/segment_tree.py
+++ b/ctools/data/structure/segment_tree.py
@@ -1,4 +1,5 @@
 import numpy as np
+from typing import Callable, Iterable, List, Optional
 
 
 class SegmentTree:
@@ -8,7 +9,7 @@ class SegmentTree:
     Interface: __init__, reduce, __setitem__, __getitem__
     """
 
-    def __init__(self, capacity, operation, neutral_element=None):
+    def __init__(self, capacity: int, operation: Callable[[Iterable[float]], float], neutral_element: Optional[float] = None):
         """
         Overview: initialize the segment tree
         Arguments:
@@ -34,7 +35,7 @@ class SegmentTree:
         # for each parent node with index i, left child is value[2*i] while right child is value[2*i+1]
         self.value = [self.neutral_element for _ in range(2 * capacity)]
 
-    def reduce(self, start=0, end=None):
+    def reduce(self, start: int = 0, end: Optional[int] = None) -> float:
         """
         Overview: reduce the tree in range [start, end)
         Arguments:
@@ -65,7 +66,7 @@ class SegmentTree:
             end = end >> 1
         return result
 
-    def __setitem__(self, idx, val):
+    def __setitem__(self, idx: int, val: List[float]):
         """
         Overview: set leaf[idx] = val and update the related nodes
         Arguments:
@@ -82,7 +83,7 @@ class SegmentTree:
             self.value[idx] = self.operation([self.value[child_base], self.value[child_base + 1]])
             idx = idx >> 1
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int) -> float:
         """
         Overview: get leaf[idx]
         Arguments:
@@ -96,10 +97,10 @@ class SegmentTree:
 
 class SumSegmentTree(SegmentTree):
 
-    def __init__(self, capacity):
+    def __init__(self, capacity: int):
         super(SumSegmentTree, self).__init__(capacity, operation=sum)
 
-    def find_prefixsum_idx(self, prefixsum, trust_caller=True):
+    def find_prefixsum_idx(self, prefixsum: float, trust_caller: bool = True) -> int:
         """
         Overview: find the highest non-zero index i, which for j in 0 <= j < i, sum_{j}leaf[j] <= prefixsum
         Arguments:
@@ -110,7 +111,7 @@ class SumSegmentTree(SegmentTree):
         """
         if not trust_caller:
             assert 0 <= prefixsum <= self.reduce() + 1e-5
-        idx = 1  # parent node
+        idx: int = 1  # parent node
         while idx < self.capacity:  # non-leaf node
             child_base = 2 * idx
             if self.value[child_base] > prefixsum:
@@ -133,5 +134,5 @@ class SumSegmentTree(SegmentTree):
 
 class MinSegmentTree(SegmentTree):
 
-    def __init__(self, capacity):
+    def __init__(self, capacity: int):
         super(MinSegmentTree, self).__init__(capacity, operation=min)


### PR DESCRIPTION
Mainly some format and type annotation updates.  
And some small bug fixes:
- remove `from torch._six import container_abcs, string_classes, int_classes` and instead use (for pytorch 1.9.0 compatibility)
```python3
import collections.abc as container_abcs
from torch._six import string_classes
int_classes = (bool, int)
```
- A bug reported with `TODO` in comment

```python3
data = self.data_source(self.batch_size, paths)  # TODO(Local State) `paths` is not defined
```
- fix a return bug in `ctools.data.structure.buffer.PrioritizedBuffer._sample_check `